### PR TITLE
Display the staticbar values correctly

### DIFF
--- a/bindings/jupyter-modules/jupyter-ma-causal/src/containers/staticbar-svg-container/index.js
+++ b/bindings/jupyter-modules/jupyter-ma-causal/src/containers/staticbar-svg-container/index.js
@@ -2,10 +2,7 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {format as d3Format} from 'd3-format';
 
-import {
-  getLineDataFactory,
-  getLineDataYDomainFactory,
-} from '../../selectors/factories';
+import {getLineDataFactory} from '../../selectors/factories';
 
 import {
   getChartWidth,
@@ -17,10 +14,8 @@ const mapStateToProps = (state, props) => {
   const {index, lineName} = props;
   // lineName: the name of the line representing the uplifting effect
   const getLineData = getLineDataFactory(index, lineName);
-  const getLineDataYDomain = getLineDataYDomainFactory(getLineData);
   return {
     data: getLineData(state),
-    domain: getLineDataYDomain(state),
     width: getChartWidth(state),
     height: getChartHeight(state),
     padding: getChartPadding(state),
@@ -37,7 +32,6 @@ class Chart extends Component {
       height,
       padding: {left, right, top, bottom},
       groupName, // treatment or control
-      domain,
     } = this.props;
 
     const format = d3Format('.2f');
@@ -59,10 +53,10 @@ class Chart extends Component {
         >
           {groupName === 'treatment'
             ? data.length
-              ? format(domain[0])
+              ? format(data[data.length - 1].y)
               : null
             : data.length
-              ? format(domain[1])
+              ? format(data[0].y)
               : null}
         </text>
       </svg>


### PR DESCRIPTION
<!-- Please do not create a Pull Request without creating an issue first, unless you are fixing typos. -->

#### Summary | Related Issue(s)

<!-- Provide a summary of your changes and link the corresponding issue(s) here -->
<!-- Put `Fixes #XXX` in your comment for auto-close. -->

![image](https://user-images.githubusercontent.com/7333962/70654448-2f2e4180-1c0b-11ea-93be-087bfb682ff5.png)

#### Changes

<!-- Describe your changes in detail -->

1. Display the staticbar labels as the y value associated with the left and right most x values instead of the y domains

#### Checklist

- [x] I have made this PR atomic.
- [x] I have provided enough context for others to review.
- ~[ ] I have added tests to cover my changes (for features and bug fixes).~
- ~[ ] I have updated the documentation and changelogs accordingly.~
- [x] All new and existing tests passed.
