### PR TITLE
fix Jupyter manifold styletron issue

### DIFF
--- a/bindings/jupyter-modules/jupyter-manifold/package.json
+++ b/bindings/jupyter-modules/jupyter-manifold/package.json
@@ -26,6 +26,9 @@
     "reduce-reducers": "^1.0.4",
     "redux": "^4.0.0",
     "redux-actions": "^2.6.5",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "styled-components": "^4.3.2",
+    "styletron-engine-atomic": "^1.4.1",
+    "styletron-react": "^5.2.1"
   }
 }

--- a/bindings/jupyter-modules/jupyter-manifold/package.json
+++ b/bindings/jupyter-modules/jupyter-manifold/package.json
@@ -26,8 +26,10 @@
     "reduce-reducers": "^1.0.4",
     "redux": "^4.0.0",
     "redux-actions": "^2.6.5",
-    "redux-thunk": "^2.3.0",
-    "styled-components": "^4.3.2",
+    "redux-thunk": "^2.3.0"
+  },
+  "peerDependencies": {
+    "styled-components": "^4.2.0",
     "styletron-engine-atomic": "^1.4.1",
     "styletron-react": "^5.2.1"
   }

--- a/bindings/jupyter-modules/jupyter-manifold/src/index.js
+++ b/bindings/jupyter-modules/jupyter-manifold/src/index.js
@@ -28,7 +28,6 @@ export default props => {
           />
           <Manifold {...props} />
         </React.Fragment>
-        ]
       </StyletronProvider>
     </Provider>
   );

--- a/bindings/jupyter-modules/jupyter-manifold/src/index.js
+++ b/bindings/jupyter-modules/jupyter-manifold/src/index.js
@@ -3,6 +3,8 @@ import {createStore, compose, applyMiddleware} from 'redux';
 import {Provider} from 'react-redux';
 import thunk from 'redux-thunk';
 import {manifoldReducer, enhanceReduxMiddleware} from '@mlvis/manifold';
+import {Client as Styletron} from 'styletron-engine-atomic';
+import {Provider as StyletronProvider} from 'styletron-react';
 import Manifold from './manifold';
 import Controls from './controls';
 import {window} from 'global';
@@ -15,15 +17,19 @@ export default props => {
     manifoldReducer,
     composeEnhancer(applyMiddleware(...enhanceReduxMiddleware([thunk])))
   );
+  const engine = new Styletron();
   return (
     <Provider store={store}>
-      <React.Fragment>
-        <Controls
-          widgetModel={props.widgetModel}
-          widgetView={props.widgetView}
-        />
-        <Manifold {...props} />
-      </React.Fragment>
+      <StyletronProvider value={engine}>
+        <React.Fragment>
+          <Controls
+            widgetModel={props.widgetModel}
+            widgetView={props.widgetView}
+          />
+          <Manifold {...props} />
+        </React.Fragment>
+        ]
+      </StyletronProvider>
     </Provider>
   );
 };

--- a/bindings/jupyter-modules/jupyter-manifold/src/manifold.js
+++ b/bindings/jupyter-modules/jupyter-manifold/src/manifold.js
@@ -1,5 +1,9 @@
 import React, {PureComponent} from 'react';
-import {Manifold, loadProcessedData, validateInputData} from '@mlvis/manifold';
+import Manifold, {
+  THEME,
+  loadProcessedData,
+  validateInputData,
+} from '@mlvis/manifold';
 import {connect} from 'react-redux';
 
 const manifoldGetState = state => state;
@@ -28,6 +32,7 @@ class ManifoldApp extends PureComponent {
         width={width}
         height={height}
         mapboxToken={mapboxAccessToken}
+        theme={THEME}
       />
     );
   }


### PR DESCRIPTION
<!-- Please do not create a Pull Request without creating an issue first, unless you are fixing typos. -->

#### Summary | Related Issue(s)

<!-- Provide a summary of your changes and link the corresponding issue(s) here -->
<!-- Put `Fixes #XXX` in your comment for auto-close. -->

The Manifold library has been modified to require an explicit styletron wrapper from the application, the jupyter-manifold thus has to been modified to accommodate that.

![image](https://user-images.githubusercontent.com/7333962/70842231-db238880-1dd5-11ea-93d0-f32ee97e9bc7.png)

#### Checklist

- [x] I have made this PR atomic.
- [x] I have provided enough context for others to review.
- ~[ ] I have added tests to cover my changes (for features and bug fixes).~
- ~[ ] I have updated the documentation and changelogs accordingly.~
- [x] All new and existing tests passed.
