### PR TITLE
Fix dependency confusion of jupyter-binding

### DIFF
--- a/bindings/jupyter/js/package.json
+++ b/bindings/jupyter/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyter-binding",
+  "name": "@mlvis/jupyter-binding",
   "version": "0.0.1",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
private package jupyter-binding could be vulnerable to a package takeover attack because it is not published on npm